### PR TITLE
Use QUERY_STRING parameter

### DIFF
--- a/REMOTE-HOST/index.php
+++ b/REMOTE-HOST/index.php
@@ -25,8 +25,7 @@ function startsWith($haystack, $needle) {
 }
 
 if ($enabled) {
-	$inurl = $_SERVER["REQUEST_URI"];
-	$code = substr($inurl, strpos($inurl, "?") + 1);    
+	$code = $_SERVER["QUERY_STRING"];
 	if (validateCode($code)) {
 		$url = $owncloud_url."/index.php/apps/shorten/code.php?code=".$code;
 		ini_set('user_agent','ownCloud Downloader;');


### PR DESCRIPTION
The query string is directly provided by PHP. Using it is more flexible than the previous method.

Example:
RewriteEngine on
RewriteRule "^s/(.+)" shorten.php?$1 [L]

In this case, index.php is renamed to shorten.php so that the domain can still be used to deliver other content.

Example URL: `example.com/s/rhabarber`
Old $code: "s/rhabarber" (incorrect)
New $code: "rhabarber" (correct)
